### PR TITLE
change "sklearn" to "scikit-learn" in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setuptools.setup(
         'pandas',
         'scipy',
         'seaborn',
-        'sklearn',
+        'scikit-learn',
         'statsmodels',
     ]
 

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
         'pandas',
         'scipy',
         'seaborn',
-        'sklearn',
+        'scikit-learn',
         'statsmodels',
     ]
 )


### PR DESCRIPTION
The correct name registered in Pypi is "scikit-learn". "sklearn" is another minor library.